### PR TITLE
for zenodo entries, allow more flexible use of RemoteLocationConfig

### DIFF
--- a/R/UtilityFunctions.R
+++ b/R/UtilityFunctions.R
@@ -224,12 +224,20 @@ loadDataFile <- function(static_file, location, type) {
   f <- paste0(directory,'/', file_name)
   
   if(!file.exists(f)){
+    if (grepl("Zenodo", location)) {
+      # Extract the entry ID from the model spec for use in url
+      id <- sub("Zenodo", "", location)
+      location <- "Zenodo"
+    } else {
+      id <- ""
+    }
     if (is.null(remoteconfig[[location]])) {
       logging::logerror(paste("The location", location," does not have a URL associated with it. ",
                               "Ensure it is listed in RemoteLocationConfig.yml"))
       return(NULL)
     } else {
-      url <- file.path(remoteconfig[[location]], remotesubdirectory)
+      url <- file.path(sub("__ID__", id, remoteconfig[[location]]),
+                       remotesubdirectory)
     }
     logging::loginfo(paste0("file not found, downloading from ", url))
     downloadDataFile(file_name, remotesubdirectory, url, query_string=query_string,

--- a/inst/extdata/RemoteLocationConfig.yml
+++ b/inst/extdata/RemoteLocationConfig.yml
@@ -1,2 +1,2 @@
 DataCommons: "https://dmap-data-commons-ord.s3.amazonaws.com"
-Zenodo17048864: "https://zenodo.org/records/17048864/files"
+Zenodo: "https://zenodo.org/records/__ID__/files"


### PR DESCRIPTION
resolves #5

New data entries from Zenodo will not require updates to `RemoteLocationConfig` as long as the ID is included in the name of the FileLocation parameter, e.g.:
> FileLocation: Zenodo17048864