### PR TITLE
Fixes issue with matrix derivation where output for sector is negative for DC model

### DIFF
--- a/R/IOFunctions.R
+++ b/R/IOFunctions.R
@@ -32,10 +32,10 @@ adjustOutputbyCPI <- function (outputyear, referenceyear, location_acronym, IsRo
 #' @return A matrix.
 normalizeIOTransactions <- function (IO_transactions_df, IO_output_df) {
   # Replace 0 in IO_transactions_df and IO_output_df with 1E-3 to avoid errors in solve(x_hat)
-  for (s in names(IO_output_df[IO_output_df == 0])){
+  for (s in names(IO_output_df[IO_output_df <= 0])){
     IO_transactions_df[s, s] <- 1E-3    
   }
-  IO_output_df[IO_output_df == 0] <- 1E-3
+  IO_output_df[IO_output_df <= 0] <- 1E-3
   Z <- as.matrix(IO_transactions_df)
   x <- unname(unlist(IO_output_df))
   x_hat <- diag(x, length(x), length(x))


### PR DESCRIPTION
Will resolve #15. Addressed with model `DCEEIOv1.3-pecan-22` built from the generic pecan spec

Setting a close to zero negative value for commodity output to 0.001 permits the DC model to build for 2022 where it previously failed.  However there are a number of outstanding issues with validation test failures. Because of this it would not be recommended to use this model for most purposes, but that is beyond the scope of this PR.

The more important question is if this change to `normalizeIOTransactions` is acceptable or if there is ever any case where output should be negative and not adjusted. 


```
> printValidationResults(m)
[1] "Validate that commodity output can be recalculated (within 1%) with the model total requirements matrix (L) and demand vector (y) for US production"
[1] "Number of sectors passing: 145"
[1] "Number of sectors failing: 1"
[1] "Sectors failing: 213/US-DC"
[1] "Validate that commodity output can be recalculated (within 1%) with model total domestic requirements matrix (L_d) and model demand (y) for US production"
[1] "Number of sectors passing: 146"
[1] "Number of sectors failing: 0"
[1] "Sectors failing: "
[1] "Validate that flow totals by commodity (E_c) can be recalculated (within 1%) using the model satellite matrix (B), market shares matrix (V_n), total requirements matrix (L), and demand vector (y) for US production"
[1] "Number of flow totals by commodity passing: 2592"
**[1] "Number of flow totals by commodity failing: 36"**
[1] "Sectors with flow totals failing: 111CA/US-DC, 211/US-DC, 212/US-DC, 213/US-DC, 3361MV/US-DC, 452/US-DC"
[1] "Validate that flow totals by commodity (E_c) can be recalculated (within 1%) using the model satellite matrix (B), market shares matrix (V_n), total domestic requirements matrix (L_d), and demand vector (y) for US production"
[1] "Number of flow totals by commodity passing: 2592"
**[1] "Number of flow totals by commodity failing: 36"**
[1] "Sectors with flow totals failing: 111CA/US-DC, 211/US-DC, 212/US-DC, 213/US-DC, 3361MV/US-DC, 452/US-DC"
[1] "Validate that commodity output are properly transformed to industry output via MarketShare"
[1] "Number of flow totals by commodity passing: 145"
[1] "Number of flow totals by commodity failing: 1"
[1] "Sectors with flow totals failing: 213/US-DC"
[1] "Validate that commodity output equals to domestic use plus production demand"
[1] "Number of flow totals by commodity passing: 146"
[1] "Number of flow totals by commodity failing: 0"
[1] "Sectors with flow totals failing: "

Checking that production demand vectors do not produce errors for 2-R models.
Calculating direct results using Production Complete final demand...
2025-11-10 15:44:48.183726 INFO::Calculating Direct + Imported Perspective LCI and LCIA with external import factors...
2025-11-10 15:44:48.189969 INFO::Result calculation complete.

Calculating final results using Production Complete final demand...

2025-11-10 15:44:48.225352 INFO::Calculating Final Perspective LCI and LCIA with external import factors...
2025-11-10 15:44:48.230808 INFO::Result calculation complete.


Checking that consumption demand vectors do not produce errors for 2-R models.

Calculating direct results using Consumption Complete final demand...
2025-11-10 15:44:48.237873 INFO::Calculating Direct + Imported Perspective LCI and LCIA with external import factors...
2025-11-10 15:44:48.243791 INFO::Result calculation complete.

Calculating final results using Consumption Complete final demand...
2025-11-10 15:44:48.249553 INFO::Calculating Final Perspective LCI and LCIA with external import factors...
2025-11-10 15:44:48.254732 INFO::Result calculation complete.

Testing that final demand vector is equivalent between standard and coupled model approaches. I.e.: y = y_m + y_d.
[1] "Mean relative difference: 0.008603042"

Testing that economic throughput is equivalement between standard and coupled model approaches for the given final demand vector.
I.e.,: x = x_dm.
[1] "Mean relative difference: 0.001334424"

Testing that LCI results are equivalent between standard and coupled model approaches (i.e., LCI = LCI_dm) when
assuming model$M = model$M_m.
[1] "Mean relative difference: 0.001851488"

Testing that LCIA results are equivalent between standard and coupled model approaches (i.e., LCIA = LCIA_dm) when
assuming model$M = model$M_m.
[1] "Mean relative difference: 0.001739112"
2025-11-10 15:44:48.277715 INFO::Calculating Final Perspective LCI and LCIA with external import factors...
2025-11-10 15:44:48.292516 INFO::Result calculation complete.

Testing that LCI emissions from households are equivalent to calculated result from Total Consumption.
[1] "Mean relative difference: 0.0009785389"
```





